### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
   "bugs": {
     "url": "https://github.com/okuryu/package-json-flatten/issues"
   },
-  "license": {
-    "type": "BSD",
-    "url": "https://github.com/okuryu/package-json-flatten/blob/master/LICENSE"
-  },
+  "license": "BSD-3-Clause",
   "author": "Ryuichi Okumura <okuryu@okuryu.com>",
   "files": [
     "LICENSE",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
